### PR TITLE
feat: allow concrete types to be used in queryable instead of BsonDo

### DIFF
--- a/Linq2MongoDB.LINQPadDriver/Linq2MongoDB.LINQPadDriver.csproj
+++ b/Linq2MongoDB.LINQPadDriver/Linq2MongoDB.LINQPadDriver.csproj
@@ -39,13 +39,13 @@
     <Content Include="FailedConnection.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="linqpad-samples/CRUD.linq">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <None Include="$(SolutionDir)README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+    <Content Update="linqpad-samples\*.linq">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <!-- This PostBuild action installs the Driver -->

--- a/Linq2MongoDB.LINQPadDriver/MongoDriver.cs
+++ b/Linq2MongoDB.LINQPadDriver/MongoDriver.cs
@@ -146,7 +146,7 @@ namespace Linq2MongoDB.LINQPadDriver
             Compile(cxInfo, source, assemblyToBuild.CodeBase, new[]{
                     typeof(IMongoDatabase).Assembly.Location,
                     typeof(BsonDocument).Assembly.Location,
-                    typeof(QueryableMongoCollection).Assembly.Location
+                    typeof(QueryableMongoCollection<>).Assembly.Location
             });
 
             // We need to tell LINQPad what to display in the TreeView on the left (Schema Explorer):

--- a/Linq2MongoDB.LINQPadDriver/linqpad-samples/ConcreteType.linq
+++ b/Linq2MongoDB.LINQPadDriver/linqpad-samples/ConcreteType.linq
@@ -1,0 +1,26 @@
+<Query Kind="Program">
+  <NuGetReference>MongoDB.Driver</NuGetReference>
+  <Namespace>MongoDB.Driver</Namespace>
+  <Namespace>MongoDB.Bson</Namespace>
+</Query>
+
+// assumes you have a connection with the collection "MyCollection"
+
+void Main()
+{
+	var query =
+	    from x in MyCollection.As<Item>()
+            where x.Name.StartsWith("A")
+            select new { 
+                id = x.Id, 
+                x.Name
+            };
+        
+	query.Dump();
+}
+
+public class Item
+{
+    public ObjectId Id { get; set; }
+    public string Name { get; set; }
+}


### PR DESCRIPTION
This change allows scripts to use local types to perform queries against the provider